### PR TITLE
Ajustes para javaEE10 - validado em wildfly 36

### DIFF
--- a/extendedValidation-core/pom.xml
+++ b/extendedValidation-core/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>com.github.ldeitos</groupId>
 		<artifactId>extendedValidation-parent</artifactId>
-		<version>3.0</version>
+		<version>3.1</version>
 		<relativePath>../extendedValidation-parent</relativePath>
 	</parent>
 

--- a/extendedValidation-core/src/main/resources/META-INF/beans.xml
+++ b/extendedValidation-core/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0">
 </beans>

--- a/extendedValidation-parent/pom.xml
+++ b/extendedValidation-parent/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.ldeitos</groupId>
 	<artifactId>extendedValidation-parent</artifactId>
-	<version>3.0</version>
+	<version>3.1</version>
 	<packaging>pom</packaging>
 	<name>Extended Validation Parent</name>
 	<description>
@@ -67,6 +67,9 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<skip>true</skip>	
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/extendedValidation/pom.xml
+++ b/extendedValidation/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>com.github.ldeitos</groupId>
 		<artifactId>extendedValidation-parent</artifactId>
-		<version>3.0</version>
+		<version>3.1</version>
 		<relativePath>../extendedValidation-parent</relativePath>
 	</parent>
 	<licenses>

--- a/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/ValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/ValidatorImpl.java
@@ -9,6 +9,7 @@ import java.security.InvalidParameterException;
 import java.util.HashSet;
 import java.util.Set;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.ValidatorFactory;
@@ -26,6 +27,7 @@ import com.github.ldeitos.validation.Validator;
  * @author <a href=mailto:leandro.deitos@gmail.com>Leandro Deitos</a>
  *
  */
+@Dependent
 @ExtendedValidator
 public class ValidatorImpl implements Validator {
 

--- a/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/configuration/ConfigInfoProvider.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/configuration/ConfigInfoProvider.java
@@ -3,12 +3,13 @@ package com.github.ldeitos.validation.impl.configuration;
 import static com.github.ldeitos.constants.Constants.CONFIGURATION_FILE;
 import static com.github.ldeitos.constants.Constants.CONFIGURATION_PATH;
 
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Singleton;
 
 /**
  * Confirg information provider. Auxiliar class to provide boot configuration informations and make easy mock in unit test. 
  */
-@Singleton
+@ApplicationScoped
 public class ConfigInfoProvider {
 
 	public String getConfigFileName() {

--- a/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/interpolator/MultipleBundlesSource.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/interpolator/MultipleBundlesSource.java
@@ -12,6 +12,7 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.CDI;
 
 import com.github.ldeitos.constants.Constants;
@@ -28,6 +29,7 @@ import com.github.ldeitos.validation.impl.configuration.ConfigInfoProvider;
  * @author <a href="mailto:leandro.deitos@gmail.com">Leandro Deitos</a>
  *
  */
+@Dependent
 public class MultipleBundlesSource extends AbstractMessagesSource {
 
 	/**

--- a/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/interpolator/PreInterpolator.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validation/impl/interpolator/PreInterpolator.java
@@ -19,6 +19,8 @@ import org.slf4j.LoggerFactory;
 import com.github.ldeitos.validation.MessagesSource;
 import com.github.ldeitos.validators.AbstractExtendedValidator;
 
+import jakarta.enterprise.context.Dependent;
+
 import java.util.Locale;
 
 /**
@@ -29,6 +31,7 @@ import java.util.Locale;
  *
  * @since 0.8.0
  */
+@Dependent
 public class PreInterpolator extends BaseInterpolator {
 
 	private static final Pattern PARAM_PATTERN = Pattern.compile(PARAMETER_PATTERN);

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/DigitsValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/DigitsValidatorImpl.java
@@ -7,6 +7,9 @@ import java.security.InvalidParameterException;
 
 import com.github.ldeitos.constraint.Digits;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class DigitsValidatorImpl extends BigDecimalComparativeValidator<Digits> 
 	implements DigitsValidator {
 	private int integerPart;

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/EmptyValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/EmptyValidatorImpl.java
@@ -8,6 +8,9 @@ import java.util.function.Predicate;
 
 import com.github.ldeitos.constraint.Empty;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class EmptyValidatorImpl extends MultiTargetValidator<Empty> implements EmptyValidator {
 
 	private static final Class<?>[] targetClasses = { Collection.class, Map.class, CharSequence.class };

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/MaxDecimalValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/MaxDecimalValidatorImpl.java
@@ -4,6 +4,9 @@ import java.math.BigDecimal;
 
 import com.github.ldeitos.constraint.DecimalMax;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MaxDecimalValidatorImpl extends BigDecimalComparativeValidator<DecimalMax> 
 	implements MaxDecimalValidator {
 	private BigDecimal maxValue;

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/MaxValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/MaxValidatorImpl.java
@@ -5,6 +5,9 @@ import java.math.BigInteger;
 
 import com.github.ldeitos.constraint.Max;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MaxValidatorImpl extends  NumberComparativeValidator<Max> 
 	implements MaxValidator {
 	

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/MinDecimalValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/MinDecimalValidatorImpl.java
@@ -4,6 +4,9 @@ import java.math.BigDecimal;
 
 import com.github.ldeitos.constraint.DecimalMin;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MinDecimalValidatorImpl extends BigDecimalComparativeValidator<DecimalMin> 
 	implements MinDecimalValidator {
 	private BigDecimal minValue;

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/MinValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/MinValidatorImpl.java
@@ -5,6 +5,9 @@ import java.math.BigInteger;
 
 import com.github.ldeitos.constraint.Min;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MinValidatorImpl extends  NumberComparativeValidator<Min> 
 	implements MinValidator {
 	

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/NotEmptyValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/NotEmptyValidatorImpl.java
@@ -8,6 +8,9 @@ import java.util.function.Predicate;
 
 import com.github.ldeitos.constraint.NotEmpty;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class NotEmptyValidatorImpl extends MultiTargetValidator<NotEmpty> implements NotEmptyValidator {
 
 	private static final Class<?>[] targetClasses = { Collection.class, Map.class, CharSequence.class };

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/PatternValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/PatternValidatorImpl.java
@@ -1,10 +1,12 @@
 package com.github.ldeitos.validators;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.validation.ConstraintValidatorContext;
 
 import com.github.ldeitos.constraint.Pattern;
 import com.github.ldeitos.constraint.Pattern.Flag;
 
+@Dependent
 public class PatternValidatorImpl implements PatternValidator {
 	private java.util.regex.Pattern pattern;
 	

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/RangeValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/RangeValidatorImpl.java
@@ -5,6 +5,9 @@ import java.math.BigInteger;
 
 import com.github.ldeitos.constraint.Range;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class RangeValidatorImpl extends NumberComparativeValidator<Range> implements RangeValidator {
 
 	private long min;

--- a/extendedValidation/src/main/java/com/github/ldeitos/validators/SizeValidatorImpl.java
+++ b/extendedValidation/src/main/java/com/github/ldeitos/validators/SizeValidatorImpl.java
@@ -10,12 +10,14 @@ import java.util.function.Predicate;
 
 import com.github.ldeitos.constraint.Size;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class SizeValidatorImpl extends MultiTargetValidator<Size> implements SizeValidator {
 
 	private static final Class<?>[] targetClasses = { Collection.class, Map.class, CharSequence.class };
 
 	private int min;
-
 	private int max;
 
 	@Override

--- a/extendedValidation/src/main/resources/META-INF/beans.xml
+++ b/extendedValidation/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0">
 </beans>

--- a/extendedValidationTestSupport/pom.xml
+++ b/extendedValidationTestSupport/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.github.ldeitos</groupId>
 		<artifactId>extendedValidation-parent</artifactId>
-		<version>3.0</version>
+		<version>3.1</version>
 		<relativePath>../extendedValidation-parent</relativePath>
 	</parent>
 	<name>Extended Validation Test Support</name>

--- a/extendedValidationTestSupport/src/main/resources/META-INF/beans.xml
+++ b/extendedValidationTestSupport/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0">
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.ldeitos</groupId>
 	<artifactId>extendedBuild</artifactId>
-	<version>3.0</version>
+	<version>3.1</version>
 	<url>http://extendedvalidation.sourceforge.net/</url>
 	<packaging>pom</packaging>
 	<properties>


### PR DESCRIPTION
Ajustes feitos para que beans sejam reconhecidos no javaEE10 - feito  para funcionar no projeto Pontua no ambiente Wildfly 36.
Obs - ajustei as versões do projeto para 3.1 mas confirmar se não existe mais algum ajuste pendente para não sobrepor a versão 3.0 atual.